### PR TITLE
Update joplin default fragility key

### DIFF
--- a/playbook-configs/joplin/datawolfWorkflow.config.dev.json
+++ b/playbook-configs/joplin/datawolfWorkflow.config.dev.json
@@ -414,7 +414,7 @@
         "variableName": "fragilityKey",
         "widget": null,
         "hidden": true,
-        "defaultValue": "",
+        "defaultValue": "retrofit_1",
         "parametersMap": [
           {
             "paramId": "28e71889-26b7-4178-b3c3-55b71b18d6bc",

--- a/playbook-configs/joplin/datawolfWorkflow.config.prod.json
+++ b/playbook-configs/joplin/datawolfWorkflow.config.prod.json
@@ -414,7 +414,7 @@
         "variableName": "fragilityKey",
         "widget": null,
         "hidden": true,
-        "defaultValue": "",
+        "defaultValue": "retrofit_1",
         "parametersMap": [
           {
             "paramId": "28e71889-26b7-4178-b3c3-55b71b18d6bc",


### PR DESCRIPTION
I realize that even though we hide the "non-retrofit", if a user left certain % of building not retrofitted, it will still fall back to the default "non-retrofit fragility...". 

A hacky fix is set the fragility key to always use retrofit_1. Let me know what you think... :-(  @navarroc 