### PR TITLE
Fix keycloak missing admin username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Fix missing keycloak admin username for cronjob
+
 ## 1.30.0 - 2024-06-12
 - IN-CORE release 5.4.0
 - Custom theme to Keycloak login page

--- a/templates/svc-maestro/cronjob.yaml
+++ b/templates/svc-maestro/cronjob.yaml
@@ -45,7 +45,7 @@ spec:
                       name: {{ include "incore.fullname" . }}-services
                       key: MAESTRO_USER_PASSWORD
                 - name: ADMIN_USERNAME
-                  value: {{ .Values.keycloak.user | quote }}
+                  value: {{ .Values.keycloak.auth.adminUser | quote }}
                 - name: ADMIN_PASSWORD
                   valueFrom:
                     secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -549,8 +549,8 @@ postgresql:
 keycloak:
   httpRelativePath: /auth/
   auth:
-    adminUser: admin
-    adminPassword: admin
+    adminUser: keycloak
+    adminPassword: keycloakAdminPassword
   proxy: edge
   ingress:
     enabled: true


### PR DESCRIPTION
Since the keycloak value structure changed, the cronjob setting needs to be upddated to reflect that. 
Right now it's not able to read the value. See the "ADMIN_USERNAME" has no value. 
Also change the default admin name to correct admin username "keycloak" since we are not overwriting that in the values yet.

<img width="329" alt="image" src="https://github.com/IN-CORE/incore-helm/assets/13950475/6581c2f0-02c7-4fdc-8118-657be4475693">
