### PR TITLE
Add additional DataWolf and configuration

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -40,6 +40,11 @@ dependencies:
   - name: datawolf
     version: ~1
     repository: https://opensource.ncsa.illinois.edu/charts
+  - name: datawolf
+    alias: datawolfcommunity
+    condition: datawolfcommunity.enabled
+    version: ~1
+    repository: https://opensource.ncsa.illinois.edu/charts
 
 # annotations for artifact.io
 annotations:

--- a/playbook-configs/galveston/datawolf.config.dev.json
+++ b/playbook-configs/galveston/datawolf.config.dev.json
@@ -1,8 +1,8 @@
 {
   "hostname": "https://incore-dev.ncsa.illinois.edu",
-  "executionGetURL": "https://dev.in-core.org/datawolf/workflows/9c1c11c8-9ba5-4125-bb35-e032095983af/executions",
-  "executionPostURL": "https://dev.in-core.org/datawolf/executions",
-  "datasetBaseURL": "https://dev.in-core.org/datawolf/datasets",
-  "datawolfPersonsDetail": "https://dev.in-core.org/datawolf/persons?email=",
+  "executionGetURL": "https://dev.in-core.org/datawolf-community/workflows/9c1c11c8-9ba5-4125-bb35-e032095983af/executions",
+  "executionPostURL": "https://dev.in-core.org/datawolf-community/executions",
+  "datasetBaseURL": "https://dev.in-core.org/datawolf-community/datasets",
+  "datawolfPersonsDetail": "https://dev.in-core.org/datawolf-community/persons?email=",
   "retreiveTimeInterval": 10000
 }

--- a/playbook-configs/galveston/datawolf.config.prod.json
+++ b/playbook-configs/galveston/datawolf.config.prod.json
@@ -1,8 +1,8 @@
 {
   "hostname": "https://incore.ncsa.illinois.edu",
-  "executionGetURL": "https://tools.in-core.org/datawolf/workflows/9c1c11c8-9ba5-4125-bb35-e032095983af/executions",
-  "executionPostURL": "https://tools.in-core.org/datawolf/executions",
-  "datasetBaseURL": "https://tools.in-core.org/datawolf/datasets",
-  "datawolfPersonsDetail": "https://tools.in-core.org/datawolf/persons?email=",
+  "executionGetURL": "https://tools.in-core.org/datawolf-community/workflows/9c1c11c8-9ba5-4125-bb35-e032095983af/executions",
+  "executionPostURL": "https://tools.in-core.org/datawolf-community/executions",
+  "datasetBaseURL": "https://tools.in-core.org/datawolf-community/datasets",
+  "datawolfPersonsDetail": "https://tools.in-core.org/datawolf-community/persons?email=",
   "retreiveTimeInterval": 10000
 }

--- a/playbook-configs/galveston/datawolfRS.config.dev.json
+++ b/playbook-configs/galveston/datawolfRS.config.dev.json
@@ -1,8 +1,8 @@
 {
 	"hostname": "https://incore-dev.ncsa.illinois.edu",
-	"executionGetURL": "https://dev.in-core.org/datawolf/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
-	"executionPostURL": "https://dev.in-core.org/datawolf/executions",
-	"datasetBaseURL": "https://dev.in-core.org/datawolf/datasets",
-	"datawolfPersonsDetail": "https://dev.in-core.org/datawolf/persons?email=",
+	"executionGetURL": "https://dev.in-core.org/datawolf-community/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
+	"executionPostURL": "https://dev.in-core.org/datawolf-community/executions",
+	"datasetBaseURL": "https://dev.in-core.org/datawolf-community/datasets",
+	"datawolfPersonsDetail": "https://dev.in-core.org/datawolf-community/persons?email=",
 	"retreiveTimeInterval": 1000
 }

--- a/playbook-configs/galveston/datawolfRS.config.prod.json
+++ b/playbook-configs/galveston/datawolfRS.config.prod.json
@@ -1,8 +1,8 @@
 {
 	"hostname": "https://incore.ncsa.illinois.edu",
-	"executionGetURL": "https://tools.in-core.org/datawolf/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
-	"executionPostURL": "https://tools.in-core.org/datawolf/executions",
-	"datasetBaseURL": "https://tools.in-core.org/datawolf/datasets",
-	"datawolfPersonsDetail": "https://tools.in-core.org/datawolf/persons?email=",
+	"executionGetURL": "https://tools.in-core.org/datawolf-community/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
+	"executionPostURL": "https://tools.in-core.org/datawolf-community/executions",
+	"datasetBaseURL": "https://tools.in-core.org/datawolf-community/datasets",
+	"datawolfPersonsDetail": "https://tools.in-core.org/datawolf-community/persons?email=",
 	"retreiveTimeInterval": 1000
 }

--- a/playbook-configs/galveston/globals.config.dev.json
+++ b/playbook-configs/galveston/globals.config.dev.json
@@ -10,6 +10,7 @@
 	"maestroServiceBase": "https://dev.in-core.org/maestro/galveston/",
 	"setGravatarURL": "https://en.gravatar.com/support/activating-your-account/",
 	"allowUpload": false,
+	"enableRunAnalysis": false,
 	"allowedRegions": [
 		{
 			"name": "Island",

--- a/playbook-configs/galveston/globals.config.prod.json
+++ b/playbook-configs/galveston/globals.config.prod.json
@@ -10,6 +10,7 @@
 	"maestroServiceBase": "https://tools.in-core.org/maestro/galveston/",
 	"setGravatarURL": "https://en.gravatar.com/support/activating-your-account/",
 	"allowUpload": false,
+	"enableRunAnalysis": false,
 	"allowedRegions": [
 		{
 			"name": "Island",

--- a/playbook-configs/joplin/datawolf.config.dev.json
+++ b/playbook-configs/joplin/datawolf.config.dev.json
@@ -1,8 +1,8 @@
 {
   "hostname": "https://incore-dev.ncsa.illinois.edu",
-  "executionGetURL": "https://dev.in-core.org/datawolf/workflows/05e5ac18-c202-4a8b-973d-01afcae20b14/executions",
-  "executionPostURL": "https://dev.in-core.org/datawolf/executions",
-  "datasetBaseURL": "https://dev.in-core.org/datawolf/datasets",
-  "datawolfPersonsDetail": "https://dev.in-core.org/datawolf/persons?email=",
+  "executionGetURL": "https://dev.in-core.org/datawolf-community/workflows/05e5ac18-c202-4a8b-973d-01afcae20b14/executions",
+  "executionPostURL": "https://dev.in-core.org/datawolf-community/executions",
+  "datasetBaseURL": "https://dev.in-core.org/datawolf-community/datasets",
+  "datawolfPersonsDetail": "https://dev.in-core.org/datawolf-community/persons?email=",
   "retreiveTimeInterval": 10000
 }

--- a/playbook-configs/joplin/datawolf.config.prod.json
+++ b/playbook-configs/joplin/datawolf.config.prod.json
@@ -1,8 +1,8 @@
 {
   "hostname": "https://incore.ncsa.illinois.edu",
-  "executionGetURL": "https://tools.in-core.org/datawolf/workflows/05e5ac18-c202-4a8b-973d-01afcae20b14/executions",
-  "executionPostURL": "https://tools.in-core.org/datawolf/executions",
-  "datasetBaseURL": "https://tools.in-core.org/datawolf/datasets",
-  "datawolfPersonsDetail": "https://tools.in-core.org/datawolf/persons?email=",
+  "executionGetURL": "https://tools.in-core.org/datawolf-community/workflows/05e5ac18-c202-4a8b-973d-01afcae20b14/executions",
+  "executionPostURL": "https://tools.in-core.org/datawolf-community/executions",
+  "datasetBaseURL": "https://tools.in-core.org/datawolf-community/datasets",
+  "datawolfPersonsDetail": "https://tools.in-core.org/datawolf-community/persons?email=",
   "retreiveTimeInterval": 10000
 }

--- a/playbook-configs/joplin/datawolfRS.config.dev.json
+++ b/playbook-configs/joplin/datawolfRS.config.dev.json
@@ -1,8 +1,8 @@
 {
 	"hostname": "https://incore-dev.ncsa.illinois.edu",
-	"executionGetURL": "https://dev.in-core.org/datawolf/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
-	"executionPostURL": "https://dev.in-core.org/datawolf/executions",
-	"datasetBaseURL": "https://dev.in-core.org/datawolf/datasets",
-	"datawolfPersonsDetail": "https://dev.in-core.org/datawolf/persons?email=",
+	"executionGetURL": "https://dev.in-core.org/datawolf-community/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
+	"executionPostURL": "https://dev.in-core.org/datawolf-community/executions",
+	"datasetBaseURL": "https://dev.in-core.org/datawolf-community/datasets",
+	"datawolfPersonsDetail": "https://dev.in-core.org/datawolf-community/persons?email=",
 	"retreiveTimeInterval": 1000
 }

--- a/playbook-configs/joplin/datawolfRS.config.prod.json
+++ b/playbook-configs/joplin/datawolfRS.config.prod.json
@@ -1,8 +1,8 @@
 {
 	"hostname": "https://incore.ncsa.illinois.edu",
-	"executionGetURL": "https://tools.in-core.org/datawolf/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
-	"executionPostURL": "https://tools.in-core.org/datawolf/executions",
-	"datasetBaseURL": "https://tools.in-core.org/datawolf/datasets",
-	"datawolfPersonsDetail": "https://tools.in-core.org/datawolf/persons?email=",
+	"executionGetURL": "https://tools.in-core.org/datawolf-community/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
+	"executionPostURL": "https://tools.in-core.org/datawolf-community/executions",
+	"datasetBaseURL": "https://tools.in-core.org/datawolf-community/datasets",
+	"datawolfPersonsDetail": "https://tools.in-core.org/datawolf-community/persons?email=",
 	"retreiveTimeInterval": 1000
 }

--- a/playbook-configs/joplin/globals.config.dev.json
+++ b/playbook-configs/joplin/globals.config.dev.json
@@ -10,6 +10,7 @@
 	"maestroServiceBase": "https://dev.in-core.org/maestro/joplin/",
 	"setGravatarURL": "https://en.gravatar.com/support/activating-your-account/",
 	"allowUpload": false,
+	"enableRunAnalysis": false,
 	"allowedRegions": null,
 	"testbedSpace": "commresiliencejoplin",
 	"testbedGroup": "incore_joplin_user",

--- a/playbook-configs/joplin/globals.config.prod.json
+++ b/playbook-configs/joplin/globals.config.prod.json
@@ -10,6 +10,7 @@
 	"maestroServiceBase": "https://tools.in-core.org/maestro/joplin/",
 	"setGravatarURL": "https://en.gravatar.com/support/activating-your-account/",
 	"allowUpload": false,
+	"enableRunAnalysis": false,
 	"allowedRegions": null,
 	"testbedSpace": "joplin-app",
 	"testbedGroup": "incore_joplin_user",

--- a/playbook-configs/slc/datawolf.config.dev.json
+++ b/playbook-configs/slc/datawolf.config.dev.json
@@ -1,8 +1,8 @@
 {
   "hostname": "https://incore-dev.ncsa.illinois.edu",
-  "executionGetURL": "https://dev.in-core.org/datawolf/workflows/c81ab517-77a3-472a-a1a6-db08d1fadb35/executions",
-  "executionPostURL": "https://dev.in-core.org/datawolf/executions",
-  "datasetBaseURL": "https://dev.in-core.org/datawolf/datasets",
-  "datawolfPersonsDetail": "https://dev.in-core.org/datawolf/persons?email=",
+  "executionGetURL": "https://dev.in-core.org/datawolf-community/workflows/c81ab517-77a3-472a-a1a6-db08d1fadb35/executions",
+  "executionPostURL": "https://dev.in-core.org/datawolf-community/executions",
+  "datasetBaseURL": "https://dev.in-core.org/datawolf-community/datasets",
+  "datawolfPersonsDetail": "https://dev.in-core.org/datawolf-community/persons?email=",
   "retreiveTimeInterval": 10000
 }

--- a/playbook-configs/slc/datawolf.config.prod.json
+++ b/playbook-configs/slc/datawolf.config.prod.json
@@ -1,8 +1,8 @@
 {
   "hostname": "https://incore.ncsa.illinois.edu",
-  "executionGetURL": "https://tools.in-core.org/datawolf/workflows/c81ab517-77a3-472a-a1a6-db08d1fadb35/executions",
-  "executionPostURL": "https://tools.in-core.org/datawolf/executions",
-  "datasetBaseURL": "https://tools.in-core.org/datawolf/datasets",
-  "datawolfPersonsDetail": "https://tools.in-core.org/datawolf/persons?email=",
+  "executionGetURL": "https://tools.in-core.org/datawolf-community/workflows/c81ab517-77a3-472a-a1a6-db08d1fadb35/executions",
+  "executionPostURL": "https://tools.in-core.org/datawolf-community/executions",
+  "datasetBaseURL": "https://tools.in-core.org/datawolf-community/datasets",
+  "datawolfPersonsDetail": "https://tools.in-core.org/datawolf-community/persons?email=",
   "retreiveTimeInterval": 10000
 }

--- a/playbook-configs/slc/datawolfRS.config.dev.json
+++ b/playbook-configs/slc/datawolfRS.config.dev.json
@@ -1,8 +1,8 @@
 {
 	"hostname": "https://incore-dev.ncsa.illinois.edu",
-	"executionGetURL": "https://dev.in-core.org/datawolf/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
-	"executionPostURL": "https://dev.in-core.org/datawolf/executions",
-	"datasetBaseURL": "https://dev.in-core.org/datawolf/datasets",
-	"datawolfPersonsDetail": "https://dev.in-core.org/datawolf/persons?email=",
+	"executionGetURL": "https://dev.in-core.org/datawolf-community/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
+	"executionPostURL": "https://dev.in-core.org/datawolf-community/executions",
+	"datasetBaseURL": "https://dev.in-core.org/datawolf-community/datasets",
+	"datawolfPersonsDetail": "https://dev.in-core.org/datawolf-community/persons?email=",
 	"retreiveTimeInterval": 1000
 }

--- a/playbook-configs/slc/datawolfRS.config.prod.json
+++ b/playbook-configs/slc/datawolfRS.config.prod.json
@@ -1,8 +1,8 @@
 {
 	"hostname": "https://incore.ncsa.illinois.edu",
-	"executionGetURL": "https://tools.in-core.org/datawolf/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
-	"executionPostURL": "https://tools.in-core.org/datawolf/executions",
-	"datasetBaseURL": "https://tools.in-core.org/datawolf/datasets",
-	"datawolfPersonsDetail": "https://tools.in-core.org/datawolf/persons?email=",
+	"executionGetURL": "https://tools.in-core.org/datawolf-community/workflows/efc14b0f-1848-4dc7-ad0d-69ef6d7f0d9c/executions",
+	"executionPostURL": "https://tools.in-core.org/datawolf-community/executions",
+	"datasetBaseURL": "https://tools.in-core.org/datawolf-community/datasets",
+	"datawolfPersonsDetail": "https://tools.in-core.org/datawolf-community/persons?email=",
 	"retreiveTimeInterval": 1000
 }

--- a/playbook-configs/slc/globals.config.dev.json
+++ b/playbook-configs/slc/globals.config.dev.json
@@ -10,6 +10,7 @@
 	"maestroServiceBase": "https://dev.in-core.org/maestro/slc/",
 	"setGravatarURL": "https://en.gravatar.com/support/activating-your-account/",
 	"allowUpload": false,
+	"enableRunAnalysis": false,
 	"allowedRegions": [
 		{
 			"name": "R1",

--- a/playbook-configs/slc/globals.config.prod.json
+++ b/playbook-configs/slc/globals.config.prod.json
@@ -10,6 +10,7 @@
 	"maestroServiceBase": "https://tools.in-core.org/maestro/slc/",
 	"setGravatarURL": "https://en.gravatar.com/support/activating-your-account/",
 	"allowUpload": false,
+	"enableRunAnalysis": false,
 	"allowedRegions": [
 		{
 			"name": "R1",

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -69,6 +69,9 @@ Playbooks:
 
 Support:
 - DataWolf      : {{ .Values.datawolf.image.tag | default .Subcharts.datawolf.Chart.AppVersion }}
+{{- if .Values.datawolfcommunity.enabled }}
+- DataWolf Comm : {{ .Values.datawolfcommunity.image.tag | default .Subcharts.datawolfcommunity.Chart.AppVersion }}
+{{- end }}
 - Postgresql    : {{ .Values.postgresql.image.tag | default .Subcharts.postgresql.Chart.AppVersion }}
 - Keycloak      : {{ .Values.keycloak.image.tag | default .Subcharts.keycloak.Chart.AppVersion }} 
 - MongoDB       : {{ .Values.mongodb.image.tag | default .Subcharts.mongodb.Chart.AppVersion }}

--- a/templates/datawolf/community-ingress.yaml
+++ b/templates/datawolf/community-ingress.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.ingress.enabled .Values.datawolfcommunity.enabled -}}
+{{- $fullName := include "incore.fullname" . -}}
+{{- $path := default "/datawolf-community/" .Values.datawolfcommunity.ingress.path -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-datawolfcommunity
+  labels:
+    {{- include "incore.labels" . | nindent 4 }}
+  annotations:
+    {{- include "incore.authIngressAnnotation" . | nindent 4 }}
+    {{- with .Values.datawolfcommunity.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: {{ $path }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}-datawolfcommunity
+                port:
+                  name: http
+    {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -531,6 +531,51 @@ datawolf:
     enabled: false
 
 # ----------------------------------------------------------------------
+# COMMUNITY DATAWOLF CONFIGURATION
+# ----------------------------------------------------------------------
+# Secondary DataWolf instance intended for community-app workflows.
+datawolfcommunity:
+  enabled: true
+
+  image:
+    repository: hub.ncsa.illinois.edu/incore/datawolf
+    tag: 4.9.0
+
+  auth:
+    enabled: false
+    admins:
+      - datawolf@incore.illinios.edu
+
+  dataset: public
+
+  loglevel: INFO
+
+  engine:
+    storelogs: true
+    nodeAffinityRequired: true
+
+  jobs:
+    nodeAffinityRequired: true
+
+  persistence:
+    size: 5Gi
+
+  postgresql:
+    enabled: false
+    url: jdbc:postgresql://postgresql/datawolfcommunity
+    postgresqlUsername: datawolfcommunity
+    postgresqlPassword: datawolfcommunity
+    postgresqlDatabase: database
+
+  # Keep defaults for dataset/file storage so this instance
+  # behaves like a standalone DataWolf deployment.
+  extraEnvVars: []
+
+  ingress:
+    enabled: false
+    path: /datawolf-community/
+
+# ----------------------------------------------------------------------
 # Maestro usersync configuration
 # ----------------------------------------------------------------------
 maestro_usersync:
@@ -600,6 +645,10 @@ postgresql:
           CREATE DATABASE datawolf;
           CREATE USER datawolf WITH PASSWORD 'datawolf';
           GRANT ALL PRIVILEGES ON DATABASE datawolf TO datawolf;
+        datawolfcommunity.sql: |
+          CREATE DATABASE datawolfcommunity;
+          CREATE USER datawolfcommunity WITH PASSWORD 'datawolfcommunity';
+          GRANT ALL PRIVILEGES ON DATABASE datawolfcommunity TO datawolfcommunity;
         maestro.sql: |
           CREATE DATABASE maestro_galveston;
           CREATE DATABASE maestro_joplin;


### PR DESCRIPTION
- Introduced a secondary DataWolf instance for community workflows in `values.yaml`.
- Updated `Chart.yaml` to include community DataWolf as a dependency.
- Modified execution and dataset URLs in configuration files for both development and production environments to reflect the new community instance.
- Added `enableRunAnalysis` flag to global configurations for both dev and prod environments.