### PR TITLE
Add auth_config.json mount for logout URL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## unreleased
+- Changed fr
+- Add auth_config.json mount to frontend for logout URL (incore-ui TODO: redirect to Keycloak on logout)
+
 ## 1.38.0 - 2025-12-15
 - IN-CORE release 6.3.0
 

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -9,3 +9,7 @@ data:
     {
       "GA_KEY": "{{- .Values.google_analytics }}"
     }
+  auth_config.json: |
+    {
+      "logoutUrl": {{ .Values.auth.logoutUrl | default "" | quote }}
+    }

--- a/templates/frontend/deployment.yaml
+++ b/templates/frontend/deployment.yaml
@@ -35,6 +35,9 @@ spec:
             - name: {{ include "incore.name" . }}-config
               mountPath: /usr/share/nginx/html/config/config.json
               subPath: ga_key.json
+            - name: {{ include "incore.name" . }}-config
+              mountPath: /usr/share/nginx/html/config/auth_config.json
+              subPath: auth_config.json
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Adds support for Keycloak logout redirect by mounting auth_config.json into the frontend.
Mount auth_config.json from the configmap in the frontend deployment
Add auth.logoutUrl and auth_config.json to the configmap template

The incore-ui app still needs to be updated to read /config/auth_config.json and redirect to the configured logout URL when the user logs out.